### PR TITLE
Remove export_mix_env function

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,6 @@ build_path=$(cd $1 && pwd)
 cache_path=$(cd $2 && pwd)
 env_path=$(cd $3 && pwd)
 
-
 source ${build_pack_path}/lib/path_funcs.sh
 source ${build_pack_path}/lib/misc_funcs.sh
 source ${build_pack_path}/lib/erlang_funcs.sh
@@ -26,7 +25,6 @@ mkdir $(platform_tools_path)
 
 load_config
 export_config_vars
-export_mix_env
 
 check_stack
 clean_cache

--- a/bin/compile
+++ b/bin/compile
@@ -25,6 +25,7 @@ mkdir $(platform_tools_path)
 
 load_config
 export_config_vars
+export_mix_env
 
 check_stack
 clean_cache

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -56,6 +56,14 @@ function export_config_vars() {
   done
 }
 
+function export_mix_env() {
+  if [ -n "${MIX_ENV}" ]; then
+    export MIX_ENV=$MIX_ENV
+  else
+    export MIX_ENV=prod
+  fi
+}
+
 function check_stack() {
   if [ "${STACK}" = "cedar" ]; then
     echo "ERROR: cedar stack is not supported, upgrade to cedar-14"

--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -56,16 +56,6 @@ function export_config_vars() {
   done
 }
 
-function export_mix_env() {
-  if [ -d $env_path ] && [ -f $env_path/MIX_ENV ]; then
-    export MIX_ENV=$(cat $env_path/MIX_ENV)
-  else
-    export MIX_ENV=prod
-  fi
-
-  output_line "* MIX_ENV=${MIX_ENV}"
-}
-
 function check_stack() {
   if [ "${STACK}" = "cedar" ]; then
     echo "ERROR: cedar stack is not supported, upgrade to cedar-14"


### PR DESCRIPTION
The `export_mix_env` function relies upon a `MIX_ENV` being set in the
`$env_path`. If no `MIX_ENV` is set, the buildpack defaults to prod.

Because we are always setting a `MIX_ENV` in our application manifest,
we don't need to rely upon this fallback. This commit removes the
`export_mix_env` function and requires users to specify a `MIX_ENV`.
